### PR TITLE
⬆️ Upgrade to FHIR version R4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 # Kids First FHIR Data Model
 
 This is an experimental repository for developing the Kids First
-FHIR data model for FHIR version STU3. The model consists of:
+FHIR data model for FHIR version R4. The model consists of:
 
-- FHIR [conformance resources](http://hl7.org/fhir/STU3/conformance-module.html) - which we call "profiles"
+- FHIR [conformance resources](http://hl7.org/fhir/R4/conformance-module.html) - which we call "profiles"
 - Non-conformance FHIR resources - which we call "resources"
 
 Kids First will use the Firely technology stack: https://simplifier.net/downloads
@@ -64,7 +64,7 @@ Vonk server for local development:
 
 1. Go to `http://www.simplifier.net` and create an account
 2. Login to your account and create a Simplifer project
-    - You must use FHIR version: STU3
+    - You must use FHIR version: R4
 3. Download the server license for your project
     - Go to `http://www.simplifier.net/<your-project-name>`
     - Click the Download button on the right, and then click
@@ -159,7 +159,7 @@ contains FHIR profiles, example resources, and implementation guides for
 a specific version of FHIR. See https://simplifier.net/learn.
 
 Everything we put in this folder will eventually be published to the corresponding
-[KidsFirstSTU3 Simplifier Project](https://simplifier.net/kidsfirststu3) so that
+[KidsFirstR4 Simplifier Project](https://simplifier.net/kidsfirstr4) so that
 stakeholders and collaborators may view the progress of the model or use it.
 
 ### FHIR Server
@@ -183,10 +183,10 @@ with the following content:
 ```json
 {
   "resourceType": "StructureDefinition",
-  "url": "http://fhirstu3.kids-first.io/fhir/StructureDefinition/PatientProfile",
+  "url": "http://fhirr4.kids-first.io/fhir/StructureDefinition/PatientProfile",
   "name": "Participant",
   "status": "draft",
-  "fhirVersion": "3.0.1",
+  "fhirVersion": "4.0.0",
   "kind": "resource",
   "abstract": false,
   "type": "Patient",
@@ -228,8 +228,8 @@ $ fhirmodel validate profile
 
 You should see something like this:
 ```
-2019-07-12 19:53:31,751 - kf_model_fhir.app - INFO - Starting FHIR 3.0.1 profile validation for /Users/singhn4/Projects/kids_first/kf-model-fhir/project/profiles
-2019-07-12 19:53:31,890 - kf_model_fhir.app - INFO - Validating FHIR 3.0.1 StructureDefinition from Participant.json
+2019-07-12 19:53:31,751 - kf_model_fhir.app - INFO - Starting FHIR 4.0.0 profile validation for /Users/singhn4/Projects/kids_first/kf-model-fhir/project/profiles
+2019-07-12 19:53:31,890 - kf_model_fhir.app - INFO - Validating FHIR 4.0.0 StructureDefinition from Participant.json
 2019-07-12 19:53:33,374 - kf_model_fhir.app - INFO - ✅ POST Participant.json to http://localhost:8080/administration/StructureDefinition succeeded
 2019-07-12 19:53:33,375 - kf_model_fhir.app - INFO - See validation results in /Users/singhn4/Projects/kids_first/kf-model-fhir/profile_validation_results.json
 2019-07-12 19:53:33,375 - kf_model_fhir.cli - INFO - ✅ Profile validation passed!
@@ -262,7 +262,7 @@ called `MyPatient.json` with the following content:
 {
     "resourceType":"Patient",
     "meta": {
-        "profile": "http://fhirstu3.kids-first.io/fhir/StructureDefinition/MyPatient"
+        "profile": "http://fhirr4.kids-first.io/fhir/StructureDefinition/MyPatient"
     },
     "name": [
         {
@@ -285,8 +285,8 @@ $ fhirmodel validate resource
 
 You should see that your validation failed for MyPatient.json.
 ```
-2019-07-12 19:57:49,020 - kf_model_fhir.app - INFO - Starting FHIR 3.0.1 resource validation for ./project/resources/MyPatient.json
-2019-07-12 19:57:49,021 - kf_model_fhir.app - INFO - Validating FHIR 3.0.1 Patient from MyPatient.json
+2019-07-12 19:57:49,020 - kf_model_fhir.app - INFO - Starting FHIR 4.0.0 resource validation for ./project/resources/MyPatient.json
+2019-07-12 19:57:49,021 - kf_model_fhir.app - INFO - Validating FHIR 4.0.0 Patient from MyPatient.json
 2019-07-12 19:57:49,833 - kf_model_fhir.app - INFO - ❌ POST MyPatient.json to http://localhost:8080/Patient/$validate failed
 2019-07-12 19:57:49,835 - kf_model_fhir.app - INFO - See validation results in /Users/singhn4/Projects/kids_first/kf-model-fhir/resource_validation_results.json
 2019-07-12 19:57:49,835 - kf_model_fhir.cli - ERROR - ❌ Resource validation failed!
@@ -357,4 +357,4 @@ branch (since its been updated with your code).
 Any time CI runs on the master branch it will do one additional step. If
 validation passes, it will publish all of the profile and resource files
 in the `./project` directory to the
-[Kids First STU3 Simplifier Project](https://simplifier.net/kidsfirststu3).
+[Kids First R4 Simplifier Project](https://simplifier.net/kidsfirstr4).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   vonk-web:
-    image: simplifier/vonk:2.0.1
+    image: simplifier/vonk:3.0.0-beta2
     volumes:
       - ./server/license:/app/license
       - ./server/appsettings.json:/app/appsettings.json

--- a/kf_model_fhir/__init__.py
+++ b/kf_model_fhir/__init__.py
@@ -1,3 +1,2 @@
 
-__fhir_version__ = '3.0.1'
 __version__ = '0.1.0'

--- a/kf_model_fhir/client.py
+++ b/kf_model_fhir/client.py
@@ -197,7 +197,7 @@ class FhirApiClient(object):
         """
         success = False
 
-        # Add fhirVersion
+        # Add request headers containing FHIR version information
         headers = request_kwargs.get('headers', {})
         headers.update(self._fhir_version_headers())
         request_kwargs['headers'] = headers
@@ -255,6 +255,12 @@ class FhirApiClient(object):
                 exit(1)
 
     def _fhir_version_headers(self):
+        """
+        Generate the FHIR Content-Type request header using the FHIR version
+        of the server
+
+        :returns: a dict containing request headers
+        """
         major_version = self.fhir_version.split('.')[0]
         return {
             'Content-Type':

--- a/kf_model_fhir/config.py
+++ b/kf_model_fhir/config.py
@@ -1,7 +1,27 @@
 import logging
 import os
 
+
+def fhir_version_name(fhir_version):
+    major_version = int(fhir_version.split('.')[0])
+
+    if major_version < 3:
+        return 'dstu2'
+    elif (major_version >= 3) and (major_version < 4):
+        return 'stu3'
+    elif (major_version >= 4) and (major_version < 5):
+        return 'r4'
+    else:
+        raise Exception(
+            f'Invalid fhir version supplied: {fhir_version}! No name exists '
+            'for the supplied fhir version.'
+        )
+
+
 DEFAULT_LOG_LEVEL = logging.DEBUG
+
+FHIR_VERSION = '4.0.0'
+FHIR_VERSION_NAME = fhir_version_name(FHIR_VERSION)
 
 ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
 PROJECT_DIR = os.path.join(ROOT_DIR, 'project')
@@ -16,13 +36,14 @@ VALIDATION_RESULTS_FILES = {'profile': 'profile_validation_results.json',
 
 SIMPLIFIER_USER = os.environ.get('SIMPLIFIER_USER')
 SIMPLIFIER_PW = os.environ.get('SIMPLIFIER_PW')
-SIMPLIFIER_PROJECT_NAME = 'KidsFirstSTU3'
-SIMPLIFIER_FHIR_SERVER_URL = f'https://stu3.simplifier.net'
+SIMPLIFIER_PROJECT_NAME = 'KidsFirstR4'
+SIMPLIFIER_FHIR_SERVER_URL = 'https://fhir.simplifier.net'
+
 
 SERVER_HOST = 'localhost'
 SERVER_PORT = '8080'
 SERVER_BASE_URL = f'http://{SERVER_HOST}:{SERVER_PORT}'
-CANONICAL_URL = 'http://fhirstu3.kids-first.io/fhir'
+CANONICAL_URL = f'http://fhir{FHIR_VERSION_NAME}.kids-first.io/fhir'
 PROFILE_ENDPOINT = 'administration/StructureDefinition'
 
 TORINOX_DOCKER_REPO = 'kidsfirstdrc/torinox'

--- a/kf_model_fhir/config.py
+++ b/kf_model_fhir/config.py
@@ -3,6 +3,14 @@ import os
 
 
 def fhir_version_name(fhir_version):
+    """
+    Get the name of a particular FHIR version number
+
+    :param: fhir_version
+    :type: str
+
+    :returns: str
+    """
     major_version = int(fhir_version.split('.')[0])
 
     if major_version < 3:

--- a/kf_model_fhir/validation.py
+++ b/kf_model_fhir/validation.py
@@ -259,7 +259,7 @@ class FhirValidator(object):
         Validate FHIR StructureDefinition(s) by POSTing new profiles
         on FHIR server
 
-        :param resource_dicts: list of dicts containing resources loade d from
+        :param resource_dicts: list of dicts containing resources loaded from
         files
         :type resource_dicts: list of dicts
 
@@ -271,6 +271,8 @@ class FhirValidator(object):
             self.logger.info('0 resources loaded. Nothing to validate')
             return success, results
 
+        # Check that fhir version in resource file matches app's
+        # config.FHIR_VERSION
         for rd in resource_dicts:
             version = rd['content'].get('fhirVersion')
             if version != FHIR_VERSION:

--- a/project/profiles/Participant.json
+++ b/project/profiles/Participant.json
@@ -1,9 +1,9 @@
 {
   "resourceType": "StructureDefinition",
-  "url": "http://fhirstu3.kids-first.io/fhir/StructureDefinition/Participant",
+  "url": "http://fhirr4.kids-first.io/fhir/StructureDefinition/Participant",
   "name": "Participant",
   "status": "draft",
-  "fhirVersion": "3.0.1",
+  "fhirVersion": "4.0.0",
   "kind": "resource",
   "abstract": false,
   "type": "Patient",

--- a/project/resources/Participant.json
+++ b/project/resources/Participant.json
@@ -1,7 +1,7 @@
 {
     "resourceType":"Patient",
     "meta": {
-        "profile": "http://fhirstu3.kids-first.io/fhir/StructureDefinition/Participant"
+        "profile": "http://fhirr4.kids-first.io/fhir/StructureDefinition/Participant"
     },
     "gender": "female",
     "name": [

--- a/server/appsettings.default.json
+++ b/server/appsettings.default.json
@@ -40,7 +40,7 @@
     "MaxConformanceResources": 5000
   },
   "MongoDbOptions": {
-    "ConnectionString": "mongodb://localhost/vonkstu3",
+    "ConnectionString": "mongodb://localhost/vonkdata",
     "EntryCollection": "vonkentries",
     "SimulateTransactions": "false"
   },

--- a/server/appsettings.json
+++ b/server/appsettings.json
@@ -42,7 +42,7 @@
     "MaxConformanceResources": 5000
   },
   "MongoDbOptions": {
-    "ConnectionString": "mongodb://vonk-mongo-db/vonkstu3",
+    "ConnectionString": "mongodb://vonk-mongo-db/vonkdata",
     "EntryCollection": "vonkentries",
     "SimulateTransactions": "false"
   },
@@ -134,7 +134,7 @@
         "Path": "/",
         "Include": [
           "Vonk.Core",
-          "Vonk.Fhir.R3",
+          "Vonk.Fhir.R4",
           "Vonk.Repository.Sql.SqlVonkConfiguration",
           "Vonk.Repository.Sqlite.SqliteVonkConfiguration",
           "Vonk.Repository.MongoDb.MongoDbVonkConfiguration",
@@ -145,6 +145,7 @@
           "Vonk.UI.Demo"
         ],
         "Exclude":[
+          "Vonk.Fhir.R3",
           "Vonk.Repository.Memory.MemoryVonkConfiguration",
           "Vonk.Repository.Sql.SqlVonkConfiguration",
           "Vonk.Repository.Sqlite.SqliteVonkConfiguration",
@@ -155,7 +156,7 @@
         "Path": "/administration",
         "Include": [
           "Vonk.Core",
-          "Vonk.Fhir.R3",
+          "Vonk.Fhir.R4",
           "Vonk.Repository.Sql.SqlAdministrationConfiguration",
           "Vonk.Repository.Sqlite.SqliteAdministrationConfiguration",
           "Vonk.Repository.MongoDb.MongoDbAdminConfiguration",
@@ -164,6 +165,7 @@
           "Vonk.Administration"
         ],
         "Exclude": [
+          "Vonk.Fhir.R3",
           "Vonk.Core.Operations",
           "Vonk.Core.Licensing.LicenseRequestJobConfiguration",
           "Vonk.Repository.Memory.MemoryAdministrationConfiguration",

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,19 @@
 import os
 from setuptools import setup, find_packages
 
+from kf_model_fhir.config import FHIR_VERSION
+
 root_dir = os.path.dirname(os.path.abspath(__file__))
 req_file = os.path.join(root_dir, 'requirements.txt')
 with open(req_file) as f:
     requirements = f.read().splitlines()
 
-fhir_version = __import__('kf_model_fhir').__fhir_version__
 version = __import__('kf_model_fhir').__version__
 
 setup(
     name='kf-model-fhir',
     version=version,
-    description=f'Kids First FHIR Model {fhir_version}',
+    description=f'Kids First FHIR Model {FHIR_VERSION}',
     packages=find_packages(),
     entry_points={
         'console_scripts': [

--- a/tests/data/profiles/InvalidParticipant0.json
+++ b/tests/data/profiles/InvalidParticipant0.json
@@ -1,3 +1,4 @@
 {
+    "fhirVersion": "4.0.0",
     "foo": "bar"
 }

--- a/tests/data/profiles/Participant.json
+++ b/tests/data/profiles/Participant.json
@@ -1,9 +1,9 @@
 {
   "resourceType": "StructureDefinition",
-  "url": "http://fhirstu3.kids-first.io/fhir/StructureDefinition/Participant",
+  "url": "http://fhirr4.kids-first.io/fhir/StructureDefinition/Participant",
   "name": "Participant",
   "status": "draft",
-  "fhirVersion": "3.0.1",
+  "fhirVersion": "4.0.0",
   "kind": "resource",
   "abstract": false,
   "type": "Patient",
@@ -18,7 +18,7 @@
           "type": [
             {
               "code": "Extension",
-              "profile": "http://fhirstu3.kids-first.io/fhir/StructureDefinition/probandStatus"
+              "profile": "http://fhirr4.kids-first.io/fhir/StructureDefinition/probandStatus"
             }
           ]
       },

--- a/tests/data/profiles/extensions/proband-status.json
+++ b/tests/data/profiles/extensions/proband-status.json
@@ -1,6 +1,6 @@
 {
     "resourceType":"StructureDefinition",
-    "url": "http://fhirstu3.kids-first.io/fhir/StructureDefinition/probandStatus",
+    "url": "http://fhirr4.kids-first.io/fhir/StructureDefinition/probandStatus",
     "name": "Proband status",
     "title": "Participant Proband Status",
     "status": "draft",
@@ -8,12 +8,14 @@
     "publisher": "Kids First DRC",
     "description": "Whether or not the participant is a proband or subject of study in the research study",
     "status":"draft",
-    "fhirVersion":"3.0.1",
+    "fhirVersion":"4.0.0",
     "kind":"complex-type",
     "abstract":false,
-    "contextType":"resource",
     "context": [
-        "Patient"
+        {
+            "type":"element",
+            "expression":"Patient"
+        }
     ],
     "type":"Extension",
     "baseDefinition":"http://hl7.org/fhir/StructureDefinition/Extension",
@@ -29,7 +31,7 @@
             {
                 "id":"Extension.url",
                 "path":"Extension.url",
-                "fixedUri":"http://fhirstu3.kids-first.io/fhir/StructureDefinition/probandStatus"
+                "fixedUri":"http://fhirr4.kids-first.io/fhir/StructureDefinition/probandStatus"
             },
             {
                 "id":"Extension.value[x]:valueBoolean",

--- a/tests/data/resources/InvalidParticipant0.json
+++ b/tests/data/resources/InvalidParticipant0.json
@@ -1,12 +1,12 @@
 {
     "resourceType":"Patient",
     "meta": {
-        "profile": "http://fhirstu3.kids-first.io/fhir/StructureDefinition/Participant"
+        "profile": "http://fhirr4.kids-first.io/fhir/StructureDefinition/Participant"
     },
     "gender": "female",
     "extension": [
         {
-            "url": "http://fhirstu3.kids-first.io/fhir/StructureDefinition/probandStatus",
+            "url": "http://fhirr4.kids-first.io/fhir/StructureDefinition/probandStatus",
             "valueBoolean": "Not a boolean"
         }
     ],

--- a/tests/data/resources/InvalidParticipant1.json
+++ b/tests/data/resources/InvalidParticipant1.json
@@ -1,7 +1,7 @@
 {
     "resourceType":"Patient",
     "meta": {
-        "profile": "http://fhirstu3.kids-first.io/fhir/StructureDefinition/Participant"
+        "profile": "http://fhirr4.kids-first.io/fhir/StructureDefinition/Participant"
     },
     "name": [
         {

--- a/tests/data/resources/InvalidParticipant2.json
+++ b/tests/data/resources/InvalidParticipant2.json
@@ -2,7 +2,7 @@
     "resourceType": "Patient",
     "gender": "female",
     "meta": {
-        "profile": "http://fhirr4.kids-first.io/fhir/StructureDefinition/oqweurpiouajfa;lk@#"
+        "profile": "http://fhirr4.kids-first.io/fhir/StructureDefinition/foobarbaz"
     },
 
     "name": [

--- a/tests/data/resources/InvalidParticipant2.json
+++ b/tests/data/resources/InvalidParticipant2.json
@@ -2,7 +2,7 @@
     "resourceType": "Patient",
     "gender": "female",
     "meta": {
-        "profile": "http://fhirstu3.kids-first.io/fhir/StructureDefinition/oqweurpiouajfa;lk@#"
+        "profile": "http://fhirr4.kids-first.io/fhir/StructureDefinition/oqweurpiouajfa;lk@#"
     },
 
     "name": [

--- a/tests/data/resources/Participant.json
+++ b/tests/data/resources/Participant.json
@@ -1,12 +1,12 @@
 {
     "resourceType":"Patient",
     "meta": {
-        "profile": "http://fhirstu3.kids-first.io/fhir/StructureDefinition/Participant"
+        "profile": "http://fhirr4.kids-first.io/fhir/StructureDefinition/Participant"
     },
     "gender": "female",
     "extension": [
         {
-            "url": "http://fhirstu3.kids-first.io/fhir/StructureDefinition/probandStatus",
+            "url": "http://fhirr4.kids-first.io/fhir/StructureDefinition/probandStatus",
             "valueBoolean": true
         }
     ],

--- a/tests/data/singles/bad-ref-extension.json
+++ b/tests/data/singles/bad-ref-extension.json
@@ -1,9 +1,9 @@
 {
   "resourceType": "StructureDefinition",
-  "url": "http://fhirstu3.kids-first.io/fhir/StructureDefinition/Participant",
+  "url": "http://fhirr4.kids-first.io/fhir/StructureDefinition/Participant",
   "name": "Participant",
   "status": "draft",
-  "fhirVersion": "3.0.1",
+  "fhirVersion": "4.0.0",
   "kind": "resource",
   "abstract": false,
   "type": "Patient",

--- a/tests/data/singles/fhir_version_conflict.json
+++ b/tests/data/singles/fhir_version_conflict.json
@@ -3,7 +3,7 @@
   "url": "http://fhirr4.kids-first.io/fhir/StructureDefinition/Participant",
   "name": "Participant",
   "status": "draft",
-  "fhirVersion": "4.0.0",
+  "fhirVersion": "foobarbaz",
   "kind": "resource",
   "abstract": false,
   "type": "Patient",
@@ -23,7 +23,7 @@
       },
       {
         "id": "Patient.animal",
-        "path": "foo.animal",
+        "path": "Patient.animal",
         "max": "0"
       }
     ]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -77,6 +77,22 @@ def test_validate_profiles_ref_ext(caplog):
     assert msg in caplog.text
 
 
+def test_validate_fhir_version(caplog):
+    """
+    Test fhir version validation
+    """
+    caplog.set_level(logging.DEBUG)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.validate,
+        ['profile',
+         '--path',
+         os.path.join(TEST_DATA_DIR, 'singles', 'fhir_version_conflict.json')]
+    )
+    assert result.exit_code != 0
+    assert 'Fhir version conflict' in str(result.exc_info)
+
+
 def test_validate_resources(caplog, profiles):
     """
     Test validate resources


### PR DESCRIPTION
Closes #59 

I won't merge this until we all agree to upgrade to R4

**TODO - Before merging**
1. Replace Kids First STU3 simplifier project with a Kids First R4 simplifier project (or pay for Simplifier so we can have more than 1 project in the account)

**STU3 Profile/Resource Migration to R4**
1. All StructureDefinition resources must have the `fhirVersion=4.0.0` key, value pair.
2. No change needed for non-StructureDefinition resources

**Notes**
If you try to send any request (GET, POST, PUT, PATCH, etc) without the correct Content-Type (application/fhir+json; fhirVersion=4.0) header to the R4 Vonk server, it throws an exception. This is probably a bug and needs to be reported. Not sure how to do that yet. 

The CLI adds this header to every request so this isn't an issue when using the CLI to do validation. However, you should keep this in mind if you use something else (e.g. Postman) to exchange data w the R4 Vonk server. 