### PR TITLE
👷 Rm docker layer caching in circleci environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ jobs:
         machine:
             # Image has Python 3.7
             image: circleci/classic:201808-01
-            docker_layer_caching: true
 
         working_directory: ~/repo
 


### PR DESCRIPTION
Unfortunately this is no longer free in circleci. This just means builds might take longer :(

![image](https://user-images.githubusercontent.com/10283712/66783853-d8c0b300-eea6-11e9-91f8-5812a22cc98e.png)
