### PR TITLE
🔧 Resolve IG Validation Errors

### DIFF
--- a/site_root/source/examples/individual-example.json
+++ b/site_root/source/examples/individual-example.json
@@ -9,7 +9,7 @@
         {
             "use": "usual",
             "family":"Smith",
-            "given": "Jack",
+            "given": ["Jack"],
             "period": {
                 "end": "2001-01-01"
             }

--- a/tests/data/resources/valid/participant-example.json
+++ b/tests/data/resources/valid/participant-example.json
@@ -2,7 +2,9 @@
     "resourceType":"Patient",
     "id": "participant-example",
     "meta": {
-        "profile": "http://fhir.kids-first.io/StructureDefinition/Participant"
+        "profile": [
+            "http://fhir.kids-first.io/StructureDefinition/Participant"
+        ]
     },
     "gender": "female",
     "name": [


### PR DESCRIPTION
The CI pipeline is failing because the version of the IG publisher it uses is still trying to pull an HL7 resource that is no longer available. Updating the CI's [IG publisher docker image](https://github.com/fhir-sci/hl7-fhir-ig-publisher) to the latest resolves this issue but causes some new validation errors because the latest IG publisher JAR has new validation logic.

This PR updates the resources to resolve the validation errors.