### PR TITLE
✨ Initial Phenotype Conformance Resources

### DIFF
--- a/site_root/input/ImplementationGuide-KidsFirst.json
+++ b/site_root/input/ImplementationGuide-KidsFirst.json
@@ -173,6 +173,54 @@
         "reference": {
           "reference": "ValueSet/species"
         }
+      },
+      {
+        "description": "Kids First StructureDefinition phenotype, Base: Observation",
+        "exampleBoolean": false,
+        "name": "Kids First StructureDefinition/phenotype",
+        "reference": {
+          "reference": "StructureDefinition/phenotype"
+        }
+      },
+      {
+        "description": "Kids First Observation ph-001, Profiles: phenotype",
+        "exampleBoolean": true,
+        "name": "Kids First Observation/ph-001",
+        "reference": {
+          "reference": "Observation/ph-001"
+        }
+      },
+      {
+        "description": "Kids First StructureDefinition age-at-event, Base: Extension",
+        "exampleBoolean": false,
+        "name": "Kids First StructureDefinition/age-at-event",
+        "reference": {
+          "reference": "StructureDefinition/age-at-event"
+        }
+      },
+      {
+        "description": "Kids First SearchParameter age-at-event",
+        "exampleBoolean": false,
+        "name": "Kids First SearchParameter/age-at-event",
+        "reference": {
+          "reference": "SearchParameter/age-at-event"
+        }
+      },
+      {
+        "description": "Kids First CodeSystem hp",
+        "exampleBoolean": false,
+        "name": "Kids First CodeSystem/hp",
+        "reference": {
+          "reference": "CodeSystem/hp"
+        }
+      },
+      {
+        "description": "Kids First ValueSet phenotype-codes",
+        "exampleBoolean": false,
+        "name": "Kids First ValueSet/phenotype-codes",
+        "reference": {
+          "reference": "ValueSet/phenotype-codes"
+        }
       }
     ]
   },

--- a/site_root/input/resources/examples/Observation-ph-001.json
+++ b/site_root/input/resources/examples/Observation-ph-001.json
@@ -1,0 +1,43 @@
+{
+  "resourceType": "Observation",
+  "id": "ph-001",
+  "meta": {
+    "profile": [
+      "http://fhir.kids-first.io/StructureDefinition/phenotype"
+    ]
+  },
+  "extension": [
+    {
+      "url": "http://fhir.kids-first.io/StructureDefinition/age-at-event",
+      "valueAge": {
+        "value": 10,
+        "unit": "d",
+        "system": "http://unitsofmeasure.org",
+        "code": "days"
+      }
+    }
+  ],
+  "status": "preliminary",
+  "code": {
+    "coding": [
+      {
+        "system": "http://purl.obolibrary.org/obo/hp.owl",
+        "code": "HP:0004307",
+        "display": "Abnormal anatomic location of the heart"
+      }
+    ],
+    "text": "Abnormal Cardiac Situs"
+  },
+  "interpretation": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+          "code": "POS",
+          "display": "Positive"
+        }
+      ],
+      "text": "Positive"
+    }
+  ]
+}

--- a/site_root/input/resources/extensions/StructureDefinition-age-at-event.json
+++ b/site_root/input/resources/extensions/StructureDefinition-age-at-event.json
@@ -1,0 +1,67 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "age-at-event",
+  "url": "http://fhir.kids-first.io/StructureDefinition/age-at-event",
+  "version": "0.1.0",
+  "name": "age-at-event",
+  "title": "Age At Event",
+  "status": "draft",
+  "description": "Age (in days since birth) of the Participant at time of event",
+  "fhirVersion": "4.0.0",
+  "kind": "complex-type",
+  "abstract": false,
+  "context": [
+    {
+      "type": "element",
+      "expression": "Condition"
+    },
+    {
+      "type": "element",
+      "expression": "Observation"
+    },
+    {
+      "type": "element",
+      "expression": "Specimen"
+    }
+  ],
+  "type": "Extension",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Extension",
+        "path": "Extension",
+        "short": "Age at event",
+        "definition": "Age (in days since birth) of the Participant at time of event",
+        "min": 0,
+        "max": "1",
+        "mustSupport": true,
+        "isModifier": false
+      },
+      {
+        "id": "Extension.extension",
+        "path": "Extension.extension"
+      },
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "type": [
+          {
+            "code": "uri"
+          }
+        ],
+        "fixedUri": "http://fhir.kids-first.io/StructureDefinition/age-at-event"
+      },
+      {
+        "id": "Extension.value[x]",
+        "path": "Extension.value[x]",
+        "type": [
+          {
+            "code": "Age"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/site_root/input/resources/extensions/StructureDefinition-age-at-event.json
+++ b/site_root/input/resources/extensions/StructureDefinition-age-at-event.json
@@ -13,11 +13,11 @@
   "context": [
     {
       "type": "element",
-      "expression": "Condition"
+      "expression": "Observation"
     },
     {
       "type": "element",
-      "expression": "Observation"
+      "expression": "Condition"
     },
     {
       "type": "element",

--- a/site_root/input/resources/profiles/StructureDefinition-phenotype.json
+++ b/site_root/input/resources/profiles/StructureDefinition-phenotype.json
@@ -1,0 +1,148 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "phenotype",
+  "url": "http://fhir.kids-first.io/StructureDefinition/phenotype",
+  "version": "0.1.0",
+  "name": "phenotype",
+  "title": "Phenotype",
+  "status": "draft",
+  "fhirVersion": "4.0.0",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Observation",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Observation",
+        "path": "Observation"
+      },
+      {
+        "id": "Observation.extension",
+        "path": "Observation.extension"
+      },
+      {
+        "id": "Observation.extension:age-at-event",
+        "path": "Observation.extension",
+        "sliceName": "age-at-event",
+        "sliceIsConstraining": false,
+        "label": "age_at_event",
+        "short": "Age time of event",
+        "definition": "Age (in days since birth) of the Participant at time of event",
+        "min": 0,
+        "max": "1",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": [
+              "http://fhir.kids-first.io/StructureDefinition/age-at-event"
+            ]
+          }
+        ],
+        "mustSupport": true,
+        "isModifier": false
+      },
+      {
+        "id": "Observation.identifier",
+        "path": "Observation.identifier",
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.basedOn",
+        "path": "Observation.basedOn",
+        "max": "0"
+      },
+      {
+        "id": "Observation.partOf",
+        "path": "Observation.partOf",
+        "max": "0"
+      },
+      {
+        "id": "Observation.category",
+        "path": "Observation.category",
+        "max": "0"
+      },
+      {
+        "id": "Observation.focus",
+        "path": "Observation.focus",
+        "max": "0"
+      },
+      {
+        "id": "Observation.encounter",
+        "path": "Observation.encounter",
+        "max": "0"
+      },
+      {
+        "id": "Observation.effective[x]",
+        "path": "Observation.effective[x]",
+        "max": "0"
+      },
+      {
+        "id": "Observation.issued",
+        "path": "Observation.issued",
+        "max": "0"
+      },
+      {
+        "id": "Observation.performer",
+        "path": "Observation.performer",
+        "max": "0"
+      },
+      {
+        "id": "Observation.value[x]",
+        "path": "Observation.value[x]",
+        "max": "0"
+      },
+      {
+        "id": "Observation.dataAbsentReason",
+        "path": "Observation.dataAbsentReason",
+        "max": "0"
+      },
+      {
+        "id": "Observation.note",
+        "path": "Observation.note",
+        "max": "0"
+      },
+      {
+        "id": "Observation.bodySite",
+        "path": "Observation.bodySite",
+        "max": "0"
+      },
+      {
+        "id": "Observation.method",
+        "path": "Observation.method",
+        "max": "0"
+      },
+      {
+        "id": "Observation.specimen",
+        "path": "Observation.specimen",
+        "max": "0"
+      },
+      {
+        "id": "Observation.device",
+        "path": "Observation.device",
+        "max": "0"
+      },
+      {
+        "id": "Observation.referenceRange",
+        "path": "Observation.referenceRange",
+        "max": "0"
+      },
+      {
+        "id": "Observation.hasMember",
+        "path": "Observation.hasMember",
+        "max": "0"
+      },
+      {
+        "id": "Observation.derivedFrom",
+        "path": "Observation.derivedFrom",
+        "max": "0"
+      },
+      {
+        "id": "Observation.component",
+        "path": "Observation.component",
+        "max": "0"
+      }
+    ]
+  }
+}

--- a/site_root/input/resources/search/SearchParameter-age-at-event.json
+++ b/site_root/input/resources/search/SearchParameter-age-at-event.json
@@ -10,11 +10,15 @@
   "description": "Searches observations by age at event",
   "code": "age-at-event",
   "base": [
-    "Observation"
+    "Observation",
+    "Condition",
+    "Specimen"
   ],
   "type": "quantity",
-  "expression": "Observation.extension.where(url = 'http://fhir.kids-first.io/StructureDefinition/age-at-event').value",
+  "expression": "Observation.extension.where(url = 'http://fhir.kids-first.io/StructureDefinition/age-at-event').value | Condition.extension.where(url = 'http://fhir.kids-first.io/StructureDefinition/age-at-event').value | Specimen.extension.where(url = 'http://fhir.kids-first.io/StructureDefinition/age-at-event').value",
   "target": [
-    "Observation"
+    "Observation",
+    "Condition",
+    "Specimen"
   ]
 }

--- a/site_root/input/resources/search/SearchParameter-age-at-event.json
+++ b/site_root/input/resources/search/SearchParameter-age-at-event.json
@@ -1,0 +1,20 @@
+{
+  "resourceType": "SearchParameter",
+  "id": "age-at-event",
+  "url": "http://fhir.kids-first.io/SearchParameter/age-at-event",
+  "version": "0.1.0",
+  "name": "age-at-event",
+  "status": "active",
+  "experimental": true,
+  "publisher": "Kids First DRC",
+  "description": "Searches observations by age at event",
+  "code": "age-at-event",
+  "base": [
+    "Observation"
+  ],
+  "type": "quantity",
+  "expression": "Observation.extension.where(url = 'http://fhir.kids-first.io/StructureDefinition/age-at-event').value",
+  "target": [
+    "Observation"
+  ]
+}

--- a/site_root/input/resources/terminology/CodeSystem-hp.json
+++ b/site_root/input/resources/terminology/CodeSystem-hp.json
@@ -1,0 +1,68 @@
+{
+  "resourceType": "CodeSystem",
+  "id": "hp",
+  "url": "http://purl.obolibrary.org/obo/hp.owl",
+  "version": "http://purl.obolibrary.org/obo/hp/releases/2020-03-27/hp.owl",
+  "name": "http://purl.obolibrary.org/obo/hp.owl",
+  "title": "Human Phenotype Ontology",
+  "status": "draft",
+  "experimental": false,
+  "description": "Please see license of HPO at http://www.human-phenotype-ontology.org",
+  "valueSet": "http://fhir.kids-first.io/ValueSet/phenotype-codes",
+  "hierarchyMeaning": "is-a",
+  "compositional": false,
+  "versionNeeded": false,
+  "content": "complete",
+  "count": 1,
+  "filter": [
+    {
+      "code": "root",
+      "operator": [
+        "="
+      ],
+      "value": "True or false."
+    },
+    {
+      "code": "deprecated",
+      "operator": [
+        "="
+      ],
+      "value": "True or false."
+    },
+    {
+      "code": "imported",
+      "operator": [
+        "="
+      ],
+      "value": "True or false"
+    }
+  ],
+  "property": [
+    {
+      "code": "parent",
+      "description": "Parent codes.",
+      "type": "code"
+    },
+    {
+      "code": "imported",
+      "description": "Indicates if the concept is imported from another code system.",
+      "type": "boolean"
+    },
+    {
+      "code": "root",
+      "description": "Indicates if this concept is a root concept (i.e. Thing is equivalent or a direct parent)",
+      "type": "boolean"
+    },
+    {
+      "code": "deprecated",
+      "description": "Indicates if this concept is deprecated.",
+      "type": "boolean"
+    }
+  ],
+  "concept": [
+    {
+      "code": "HP:0004307",
+      "display": "Abnormal anatomic location of the heart"
+    }
+  ]
+}

--- a/site_root/input/resources/terminology/ValueSet-phenotype-codes.json
+++ b/site_root/input/resources/terminology/ValueSet-phenotype-codes.json
@@ -1,0 +1,19 @@
+{
+  "resourceType": "ValueSet",
+  "id": "phenotype-codes",
+  "url": "http://fhir.kids-first.io/ValueSet/phenotype-codes",
+  "version": "0.1.0",
+  "name": "phenotype-codes",
+  "title": "Phenotype Codes",
+  "status": "draft",
+  "experimental": false,
+  "publisher": "Kids First DRC",
+  "description": "This value set includes all codes from Human Phenotype Ontology.",
+  "compose": {
+    "include": [
+      {
+        "system": "http://purl.obolibrary.org/obo/hp.owl"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #26 

**Dependencies**

- [x] Extension `StructureDefinition/age-at-event`
- [x] `CodeSystem/hp`
- [x] `ValueSet/phenotype-codes` that combines HPO and SNOMED CT

**To do:**
- [x] Add `age-at-event` extension to Phenotype StructureDefinition
- [x] Update `Observation-ph-001.json` with `age-at-event` populated
- [ ] Bind `ValueSet/phenotype-codes` to phenotype.code
- [x] Update `Observation-ph-001.json` with code fully populated

**Mapping Spreadsheet**
https://docs.google.com/spreadsheets/d/19tQnE75UzvP_k29D-QprbsJ-6ZO2PdUmKPiWHKkcTEg/edit#gid=1197884015