### PR TITLE
🐛 Resolve name conflicts w/generated IG output files

### DIFF
--- a/kf_model_fhir/app.py
+++ b/kf_model_fhir/app.py
@@ -172,8 +172,8 @@ def add_resource_to_ig(resource_filepath, ig_control_filepath,
             )
         entry = {
             f"{rtype}/{r_id}": {
-                "base": f"{r_id}.html",
-                "defns": f"{r_id}-definitions.html"
+                "base": f"{rtype}-{r_id}.html",
+                "defns": f"{rtype}-{r_id}-definitions.html"
             }
         }
     # Example resource


### PR DESCRIPTION
Generated IG configuration (from fhirmodel add cmd) was causing some
IG output files to have same name because it used only resource id to produce file name.

Fix by naming files using resource type and id to produce unique file names.