### PR TITLE
🚧 remove unused resource

### DIFF
--- a/site_root/input/ImplementationGuide-KidsFirst.json
+++ b/site_root/input/ImplementationGuide-KidsFirst.json
@@ -391,14 +391,6 @@
         }
       },
       {
-        "description": "Kids First StructureDefinition kfdrc-research-study-no-phi, Base: kfdrc-research-study",
-        "exampleBoolean": false,
-        "name": "Kids First StructureDefinition/kfdrc-research-study-no-phi",
-        "reference": {
-          "reference": "StructureDefinition/kfdrc-research-study-no-phi"
-        }
-      },
-      {
         "description": "Kids First CodeSystem cdcrec",
         "exampleBoolean": false,
         "name": "Kids First CodeSystem/cdcrec",

--- a/site_root/input/ignoreWarnings.txt
+++ b/site_root/input/ignoreWarnings.txt
@@ -1,0 +1,1 @@
+== Suppressed Messages ==

--- a/tests/data/site_root/input/ignoreWarnings.txt
+++ b/tests/data/site_root/input/ignoreWarnings.txt
@@ -1,0 +1,1 @@
+== Suppressed Messages ==


### PR DESCRIPTION
This PR 
  - Removes an unused resource from the IG, closes #151; and
  - Formats the suppressed warnings file (See ncpi-fhir/hl7-fhir-ig-publisher#26 in detail)