### PR TITLE
🔧 Uncycle example patient references

### DIFF
--- a/site_root/input/resources/examples/Patient-pt-001-no-phi.json
+++ b/site_root/input/resources/examples/Patient-pt-001-no-phi.json
@@ -53,54 +53,6 @@
         ],
         "text": "Homo Sapiens"
       }
-    },
-    {
-      "url": "http://fhir.kids-first.io/StructureDefinition/relation",
-      "extension": [
-        {
-          "url": "subject",
-          "valueReference": {
-            "reference": "Patient/pt-002"
-          }
-        },
-        {
-          "url": "relation",
-          "valueCodeableConcept": {
-            "coding": [
-              {
-                "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                "code": "MTH",
-                "display": "mother"
-              }
-            ],
-            "text": "Mother"
-          }
-        }
-      ]
-    },
-    {
-      "url": "http://fhir.kids-first.io/StructureDefinition/relation",
-      "extension": [
-        {
-          "url": "subject",
-          "valueReference": {
-            "reference": "Patient/pt-003"
-          }
-        },
-        {
-          "url": "relation",
-          "valueCodeableConcept": {
-            "coding": [
-              {
-                "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                "code": "FTH",
-                "display": "father"
-              }
-            ],
-            "text": "Father"
-          }
-        }
-      ]
     }
   ],
   "identifier": [

--- a/site_root/input/resources/examples/Patient-pt-001.json
+++ b/site_root/input/resources/examples/Patient-pt-001.json
@@ -53,54 +53,6 @@
         ],
         "text": "Homo Sapiens"
       }
-    },
-    {
-      "url": "http://fhir.kids-first.io/StructureDefinition/relation",
-      "extension": [
-        {
-          "url": "subject",
-          "valueReference": {
-            "reference": "Patient/pt-002"
-          }
-        },
-        {
-          "url": "relation",
-          "valueCodeableConcept": {
-            "coding": [
-              {
-                "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                "code": "MTH",
-                "display": "mother"
-              }
-            ],
-            "text": "Mother"
-          }
-        }
-      ]
-    },
-    {
-      "url": "http://fhir.kids-first.io/StructureDefinition/relation",
-      "extension": [
-        {
-          "url": "subject",
-          "valueReference": {
-            "reference": "Patient/pt-003"
-          }
-        },
-        {
-          "url": "relation",
-          "valueCodeableConcept": {
-            "coding": [
-              {
-                "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                "code": "FTH",
-                "display": "father"
-              }
-            ],
-            "text": "Father"
-          }
-        }
-      ]
     }
   ],
   "identifier": [


### PR DESCRIPTION
The server doesn't accept submission of PT1 because it references PT2/3
and those don't exist in the server yet.