### PR TITLE
🚚 Rename 'group' to 'family'

### DIFF
--- a/kf_model_fhir/ingest_plugin/kids_first_fhir.py
+++ b/kf_model_fhir/ingest_plugin/kids_first_fhir.py
@@ -29,7 +29,7 @@ from kf_model_fhir.ingest_plugin.target_api_builders.practitioner_role import (
 from kf_model_fhir.ingest_plugin.target_api_builders.kfdrc_patient import (
     Patient,
 )
-from kf_model_fhir.ingest_plugin.target_api_builders.group import Group
+from kf_model_fhir.ingest_plugin.target_api_builders.family import Family
 from kf_model_fhir.ingest_plugin.target_api_builders.kfdrc_research_study import (
     ResearchStudy,
 )
@@ -55,7 +55,7 @@ all_targets = [
     Organization,
     PractitionerRole,
     Patient,
-    Group,
+    Family,
     ResearchStudy,
     PatientRelation,
     Condition,

--- a/kf_model_fhir/ingest_plugin/target_api_builders/family.py
+++ b/kf_model_fhir/ingest_plugin/target_api_builders/family.py
@@ -18,8 +18,8 @@ group_type = {
 }
 
 
-class Group:
-    class_name = "group"
+class Family:
+    class_name = "family"
     resource_type = "Group"
     target_id_concept = CONCEPT.FAMILY.TARGET_SERVICE_ID
 
@@ -56,8 +56,8 @@ class Group:
         ]
 
         return {
-            "resourceType": Group.resource_type,
-            "id": get_target_id_from_record(Group, record),
+            "resourceType": Family.resource_type,
+            "id": get_target_id_from_record(Family, record),
             "meta": {
                 "profile": ["http://hl7.org/fhir/StructureDefinition/Group"]
             },
@@ -68,7 +68,7 @@ class Group:
                 },
                 {
                     "system": "urn:kids-first:unique-string",
-                    "value": join(Group.resource_type, study_id, key),
+                    "value": join(Family.resource_type, study_id, key),
                 },
             ],
             "type": group_type.get(species) or "person",

--- a/kf_model_fhir/ingest_plugin/target_api_builders/kfdrc_research_study.py
+++ b/kf_model_fhir/ingest_plugin/target_api_builders/kfdrc_research_study.py
@@ -12,7 +12,7 @@ from kf_model_fhir.ingest_plugin.target_api_builders.organization import (
 from kf_model_fhir.ingest_plugin.target_api_builders.practitioner import (
     Practitioner,
 )
-from kf_model_fhir.ingest_plugin.target_api_builders.group import Group
+from kf_model_fhir.ingest_plugin.target_api_builders.family import Family
 from kf_model_fhir.ingest_plugin.shared import join, make_identifier
 
 
@@ -105,7 +105,7 @@ class ResearchStudy:
         if families:
             entity["enrollment"] = [
                 {
-                    "reference": f"Group/{get_target_id_from_record(Group, family)}"
+                    "reference": f"{Family.resource_type}/{get_target_id_from_record(Family, family)}"
                 }
                 for family in families
             ]


### PR DESCRIPTION
Group is too generic. There may be other groups (e.g. cohort)