### PR TITLE
🐛👷 Shallow clones hide remote branches

### DIFF
--- a/.github/prepare_assets.sh
+++ b/.github/prepare_assets.sh
@@ -7,8 +7,9 @@ pip install .
 fhirutil validate --publisher_opts="-tx n/a" --clear_output site_root/ig.ini
 
 # replace gh-pages root ig directory with site_root/output
+git remote set-branches origin '*'
 git fetch origin gh-pages
-git checkout gh-pages
+git checkout -f gh-pages
 git rm -rf --ignore-unmatch ig
 mv -f site_root/output ig
 mkdir -p not_needed_for_ig_site


### PR DESCRIPTION
Apparently if you shallow clone and then decide you want to look at a different remote branch, you then have to `git remote set-branches origin '*'` before you fetch the branch. Otherwise git says "Ok, I fetched it!" but doesn't actually do anything, even if you fetch --unshallow.