### PR TITLE
🐛 Modify kfdrc-vital-status example resource and remove lingering "in days" description

### DIFF
--- a/site_root/input/resources/examples/Observation-vs-001-no-phi.json
+++ b/site_root/input/resources/examples/Observation-vs-001-no-phi.json
@@ -30,14 +30,23 @@
     "coding": [
       {
         "system": "http://snomed.info/sct",
-        "code": "438949009",
-        "display": "Alive (finding)"
+        "code": "263493007",
+        "display": "Clinical status"
       }
     ],
-    "text": "Alive"
+    "text": "Clinical status"
   },
   "subject": {
     "reference": "Patient/pt-001"
   },
-  "valueBoolean": true
+  "valueCodeableConcept": {
+    "coding": [
+      {
+        "code": "438949009",
+        "system": "http://snomed.info/sct",
+        "display": "Alive"
+      }
+    ],
+    "text": "Alive"
+  }
 }

--- a/site_root/input/resources/examples/Observation-vs-001.json
+++ b/site_root/input/resources/examples/Observation-vs-001.json
@@ -30,15 +30,24 @@
     "coding": [
       {
         "system": "http://snomed.info/sct",
-        "code": "438949009",
-        "display": "Alive (finding)"
+        "code": "263493007",
+        "display": "Clinical status"
       }
     ],
-    "text": "Alive"
+    "text": "Clinical status"
   },
   "subject": {
     "reference": "Patient/pt-001"
   },
   "effectiveDateTime": "2019-06-15",
-  "valueBoolean": true
+  "valueCodeableConcept": {
+    "coding": [
+      {
+        "code": "438949009",
+        "system": "http://snomed.info/sct",
+        "display": "Alive"
+      }
+    ],
+    "text": "Alive"
+  }
 }

--- a/site_root/input/resources/profiles/StructureDefinition-kfdrc-phenotype.json
+++ b/site_root/input/resources/profiles/StructureDefinition-kfdrc-phenotype.json
@@ -29,7 +29,7 @@
         "sliceIsConstraining": false,
         "label": "age_at_event",
         "short": "Age at the time of phenotype observation",
-        "definition": "Age (in days since birth) of the Kids First DRC Patient at the time of phenotype observation.",
+        "definition": "Age (since birth) of the Kids First DRC Patient at the time of phenotype observation.",
         "min": 0,
         "max": "1",
         "type": [

--- a/site_root/input/resources/profiles/StructureDefinition-kfdrc-specimen.json
+++ b/site_root/input/resources/profiles/StructureDefinition-kfdrc-specimen.json
@@ -39,7 +39,7 @@
         "sliceIsConstraining": false,
         "label": "age_at_event",
         "short": "Age at the time of Specimen collection",
-        "definition": "Age (in days since birth) of the Kids First DRC Patient at the time of Specimen collection.",
+        "definition": "Age (since birth) of the Kids First DRC Patient at the time of Specimen collection.",
         "min": 0,
         "max": "1",
         "type": [

--- a/site_root/input/resources/profiles/StructureDefinition-kfdrc-vital-status.json
+++ b/site_root/input/resources/profiles/StructureDefinition-kfdrc-vital-status.json
@@ -29,7 +29,7 @@
         "sliceIsConstraining": false,
         "label": "age_at_event",
         "short": "Age time of event",
-        "definition": "Age (in days since birth) of the Participant at time of vital status observation",
+        "definition": "Age (since birth) of the Participant at time of vital status observation",
         "min": 0,
         "max": "1",
         "type": [


### PR DESCRIPTION
This PR:

- modifies the `kfdrc-vital-status` example resources (`Observation-vs-001.json` and `Observation-vs-001-no-phi.json`); and 
- removes lingering "in days" descriptions

It closes #200 and closes #182.