### PR TITLE
♻️ New ingest plugin for v2 plugin model

### DIFF
--- a/kf_model_fhir/ingest_plugin/shared.py
+++ b/kf_model_fhir/ingest_plugin/shared.py
@@ -1,10 +1,91 @@
+import os
 import re
+from pprint import pformat
+
+from kf_lib_data_ingest.common import constants
+from ncpi_fhir_utility.client import FhirApiClient
+from requests import RequestException
 
 
-def join(*args):
-    return "|".join(str(a) for a in args)
+def not_none(val):
+    assert val is not None
+    return val
 
 
 # http://hl7.org/fhir/R4/datatypes.html#id
-def make_identifier(*args):
+def make_id(*args):
     return re.sub(r"[^A-Za-z0-9\-\.]", "-", ".".join(str(a) for a in args))[:64]
+
+
+def flexible_age(record, days_concept, generic_concept):
+    age = record.get(days_concept)
+    units = record.get(generic_concept.UNITS)
+    value = record.get(generic_concept.VALUE)
+
+    if (age is None) and (units is not None) and (value is not None):
+        if units == constants.AGE.UNITS.DAYS:
+            age = int(value)
+        elif units == constants.AGE.UNITS.MONTHS:
+            age = int(value * 30.44)
+        elif units == constants.AGE.UNITS.YEARS:
+            age = int(value * 365.25)
+
+    return age
+
+
+FHIR_USER = os.getenv("FHIR_USER") or "admin"
+FHIR_PW = os.getenv("FHIR_PW") or "password"
+clients = {}
+
+
+def submit(host, entity_class, body):
+    clients[host] = clients.get(host) or FhirApiClient(
+        base_url=host, auth=(FHIR_USER, FHIR_PW)
+    )
+
+    # drop empty fields
+    body = {k: v for k, v in body.items() if v not in (None, [], {})}
+
+    verb = "POST"
+    api_path = f"{host}/{entity_class.resource_type}"
+    if body.get("id"):
+        verb = "PUT"
+        body["id"] = make_id(body["id"])
+        api_path = f"{api_path}/{body['id']}"
+        if "patches" in body:
+            verb = "PATCH"
+            body = body["patches"]
+
+    cheaders = clients[host]._fhir_version_headers()
+    if verb == "PATCH":
+        cheaders["Content-Type"] = cheaders["Content-Type"].replace(
+            "application/fhir", "application/json-patch"
+        )
+
+    success, result = clients[host].send_request(
+        verb, api_path, json=body, headers=cheaders
+    )
+
+    if (
+        (not success)
+        and (verb == "PUT")
+        and (
+            "no resource with this ID exists"
+            in result.get("response", {})
+            .get("issue", [{}])[0]
+            .get("diagnostics", "")
+        )
+    ):
+        verb = "POST"
+        api_path = f"{host}/{entity_class.resource_type}"
+        success, result = clients[host].send_request(
+            verb, api_path, json=body, headers=cheaders
+        )
+
+    if success:
+        return result["response"]["id"]
+    else:
+        raise RequestException(
+            f"Sent {verb} request to {api_path}:\n{pformat(body)}"
+            f"\nGot:\n{pformat(result)}"
+        )

--- a/kf_model_fhir/ingest_plugin/target_api_builders/kfdrc_phenotype.py
+++ b/kf_model_fhir/ingest_plugin/target_api_builders/kfdrc_phenotype.py
@@ -4,11 +4,14 @@ from rows of tabular participant phenotype data.
 """
 from kf_lib_data_ingest.common import constants
 from kf_lib_data_ingest.common.concept_schema import CONCEPT
-
+from kf_model_fhir.ingest_plugin.shared import (
+    flexible_age,
+    not_none,
+    submit,
+)
 from kf_model_fhir.ingest_plugin.target_api_builders.kfdrc_patient import (
     Patient,
 )
-from kf_model_fhir.ingest_plugin.shared import join
 
 # https://www.hl7.org/fhir/valueset-observation-interpretation.html
 interpretation = {
@@ -30,52 +33,23 @@ class Phenotype:
     resource_type = "Observation"
     target_id_concept = CONCEPT.PHENOTYPE.TARGET_SERVICE_ID
 
-    @staticmethod
-    def build_key(record):
-        assert None is not record[CONCEPT.PARTICIPANT.ID]
-        assert None is not record[CONCEPT.PHENOTYPE.NAME]
-        assert record[CONCEPT.PHENOTYPE.OBSERVED] in interpretation
-        return record.get(CONCEPT.PHENOTYPE.UNIQUE_KEY) or join(
-            record[CONCEPT.PARTICIPANT.ID],
-            record[CONCEPT.PHENOTYPE.NAME],
-            record[CONCEPT.PHENOTYPE.OBSERVED],
-            record.get(CONCEPT.PHENOTYPE.EVENT_AGE_DAYS),
-        )
+    @classmethod
+    def get_key_components(cls, record, get_target_id_from_record):
+        phenotype_name = not_none(record[CONCEPT.PHENOTYPE.NAME])
+        patient_id = not_none(get_target_id_from_record(Patient, record))
 
-    @staticmethod
-    def build_entity(record, key, get_target_id_from_record):
-        study_id = record[CONCEPT.STUDY.ID]
-        phenotype_name = record.get(CONCEPT.PHENOTYPE.NAME)
-        event_age_days = record.get(CONCEPT.PHENOTYPE.EVENT_AGE_DAYS)
-        observed = record.get(CONCEPT.PHENOTYPE.OBSERVED)
-        hpo_id = record.get(CONCEPT.PHENOTYPE.HPO_ID)
-
-        entity = {
-            "resourceType": Phenotype.resource_type,
-            "id": get_target_id_from_record(Phenotype, record),
-            "meta": {
-                "profile": [
-                    "http://fhir.kids-first.io/StructureDefinition/kfdrc-phenotype"
-                ]
-            },
-            "identifier": [
-                {
-                    "system": "urn:kids-first:unique-string",
-                    "value": join(Phenotype.resource_type, study_id, key),
-                }
-            ],
-            "status": "preliminary",
-            "code": {"coding": [{"code": hpo_id}], "text": phenotype_name},
-            "subject": {
-                "reference": f"Patient/{get_target_id_from_record(Patient, record)}"
-            },
-            "interpretation": [
-                {"coding": [interpretation[observed]], "text": observed}
-            ],
+        key_components = {
+            "code": {"text": phenotype_name},
+            "subject": {"reference": f"{Patient.resource_type}/{patient_id}"},
         }
 
+        event_age_days = flexible_age(
+            record,
+            CONCEPT.PHENOTYPE.EVENT_AGE_DAYS,
+            CONCEPT.PHENOTYPE.EVENT_AGE,
+        )
         if event_age_days:
-            entity.setdefault("extension", []).append(
+            key_components.setdefault("extension", []).append(
                 {
                     "url": "http://fhir.kids-first.io/StructureDefinition/age-at-event",
                     "valueAge": {
@@ -86,5 +60,46 @@ class Phenotype:
                     },
                 }
             )
+        return key_components
+
+    @classmethod
+    def query_target_ids(cls, host, key_components):
+        pass
+
+    @classmethod
+    def build_entity(cls, record, get_target_id_from_record):
+        observed = record.get(CONCEPT.PHENOTYPE.OBSERVED)
+
+        entity = {
+            "resourceType": cls.resource_type,
+            "id": get_target_id_from_record(cls, record),
+            "meta": {
+                "profile": [
+                    "http://fhir.kids-first.io/StructureDefinition/kfdrc-phenotype"
+                ]
+            },
+            "identifier": [],
+            "status": "preliminary",
+            "interpretation": [
+                {"coding": [interpretation[observed]], "text": observed}
+            ],
+        }
+
+        entity = {
+            **cls.get_key_components(record, get_target_id_from_record),
+            **entity,
+        }
+
+        hpo_id = record.get(CONCEPT.PHENOTYPE.HPO_ID)
+        if hpo_id:
+            entity["code"].setdefault("coding", []).append(
+                {
+                    "code": hpo_id,
+                }
+            )
 
         return entity
+
+    @classmethod
+    def submit(cls, host, body):
+        return submit(host, cls, body)

--- a/kf_model_fhir/ingest_plugin/target_api_builders/practitioner.py
+++ b/kf_model_fhir/ingest_plugin/target_api_builders/practitioner.py
@@ -3,39 +3,49 @@ Builds FHIR Practitioner resources (https://www.hl7.org/fhir/practitioner.html)
 from rows of tabular investigator metadata.
 """
 from kf_lib_data_ingest.common.concept_schema import CONCEPT
-
-from kf_model_fhir.ingest_plugin.shared import join, make_identifier
+from kf_model_fhir.ingest_plugin.shared import not_none, submit
 
 
 class Practitioner:
     class_name = "practitioner"
     resource_type = "Practitioner"
+    # PractitionerRole already uses CONCEPT.INVESTIGATOR.TARGET_SERVICE_ID,
+    # so the below is set to None
     target_id_concept = None
 
-    @staticmethod
-    def build_key(record):
-        assert None is not record[CONCEPT.INVESTIGATOR.NAME]
-        return join(record[CONCEPT.INVESTIGATOR.NAME])
-
-    @staticmethod
-    def build_entity(record, key, get_target_id_from_record):
-        investigator_name = record.get(CONCEPT.INVESTIGATOR.NAME)
-
+    @classmethod
+    def get_key_components(cls, record, get_target_id_from_record):
+        investigator_name = not_none(record[CONCEPT.INVESTIGATOR.NAME])
         return {
-            "resourceType": Practitioner.resource_type,
-            "id": make_identifier(
-                Practitioner.resource_type, investigator_name
-            ),
+            "identifier": [
+                {
+                    "system": "https://kf-api-dataservice.kidsfirstdrc.org/investigators?",
+                    "value": f"name={investigator_name}",
+                }
+            ],
+            "name": [{"text": investigator_name}],
+        }
+
+    @classmethod
+    def query_target_ids(cls, host, key_components):
+        pass
+
+    @classmethod
+    def build_entity(cls, record, get_target_id_from_record):
+        entity = {
+            "resourceType": cls.resource_type,
+            "id": get_target_id_from_record(cls, record),
             "meta": {
                 "profile": [
                     "http://hl7.org/fhir/StructureDefinition/Practitioner"
                 ]
             },
-            "identifier": [
-                {
-                    "system": "https://kf-api-dataservice.kidsfirstdrc.org/investigators?name=",
-                    "value": investigator_name,
-                }
-            ],
-            "name": [{"text": investigator_name}],
         }
+        return {
+            **cls.get_key_components(record, get_target_id_from_record),
+            **entity,
+        }
+
+    @classmethod
+    def submit(cls, host, body):
+        return submit(host, cls, body)


### PR DESCRIPTION
The ingest library loader is being upgraded to remove the strict dependency on local cache. This requires a new target service plugin. 

The new query_target_ids methods will ultimately need to be populated for this change to make a difference in use. They are left as stubs for now, which should give similar performance as before.

CI tests will fail until the library PR is merged. Test locally with https://github.com/kids-first/kf-lib-data-ingest/pull/513 + https://github.com/kids-first/kf-lib-data-ingest/pull/514

Please don't just evaluate this for correctness. Also make sure that it looks like a good idea.